### PR TITLE
Only run pipelines in deployment environment

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,13 @@
 steps:
   - label: ":hugo:"
+    agents:
+      deploy-nchlswhttkr.com: true
     command: hugo
   - wait
   - label: ":shipit:"
     branches: master
+    agents:
+      deploy-nchlswhttkr.com: true
     command:
       - hugo
       - rsync -a --chown :nchlswhttkr.com --delete $PWD/public/ /home/nchlswhttkr/nchlswhttkr.com


### PR DESCRIPTION
Closes #7

I've put a tag (`deploy-nchlswhttkr.com=true`) on the Buildkite agent running in the deployment environment, and pipelines will only run on agents with the aforementioned tag.

Maybe it's not as clean as just running rsync over SSH, but it saves me the work of having to pass secrets around in builds.