### PR TITLE
Publish Newsletter

### DIFF
--- a/archetypes/newsletter.md
+++ b/archetypes/newsletter.md
@@ -1,0 +1,19 @@
+---
+# prettier-ignore
+title: "Newsletter #{{ printf .TranslationBaseName }}"
+date: {{ printf "%sT12:00:00.000Z" ( now.Format "2006-01-02" ) }}
+---
+
+<!--more-->
+
+<!--
+{{% newsletter-heading "" %}}
+
+{{% newsletter-title %}}
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+{{%/ newsletter-description %}}
+{{% newsletter-link "" %}}
+
+---
+-->

--- a/content/_index.md
+++ b/content/_index.md
@@ -19,6 +19,8 @@ I study Computer Science at Monash University. I've been involved with IT at Mon
 
 I like to write down my thoughts and experiences every now and them, feel free to [give them a read](/blog/)!
 
+I'm also trying out curating a small [newsletter](/newsletter/) of content I find interesting.
+
 ---
 
 ## [Resume](/resume/)

--- a/content/newsletter/2020-01.md
+++ b/content/newsletter/2020-01.md
@@ -1,0 +1,102 @@
+---
+# prettier-ignore
+title: "Newsletter #2020-01"
+date: 2020-01-31T12:00:00.000Z
+---
+
+<!--more-->
+
+{{% newsletter-heading "Articles" %}}
+
+{{% newsletter-title %}}
+Testing Signed and Encrypted Cookies in Rails
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+A writeup on testing cookies in a Rails application that I enjoyed reading.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://philna.sh/blog/2020/01/15/test-signed-cookies-in-rails/" %}}
+
+---
+
+{{% newsletter-title %}}
+How do ECMAScript Private Fields Work in TypeScript?
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+Digs into the output from the TypeScript compiler, exploring some interesting JavaScript use.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://www.aaron-powell.com/posts/2020-01-23-typescript-ecmascript-class-private-fields/" %}}
+
+---
+
+{{% newsletter-title %}}
+The Music of Pokémon Mystery Dungeon: Explorers of Time, Darkness and Sky
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+The soundtracks of the Pokémon games really hit their stride in the fourth generation, and this analysis captures how music conveys emotion in this iteration of the Mystery Dungeon series.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://daily.pokecommunity.com/2016/10/06/music-pokemon-mystery-dungeon-explorers/" %}}
+
+---
+
+{{% newsletter-heading "Videos" %}}
+
+{{% newsletter-title %}}
+The Engoodening of No Man's Sky
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+Videos from Internet Historian are always a treasure, but this telling of the disastrous launch of No Man's Sky and its later redepemtion is particularly captivating.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://www.youtube.com/watch?v=O5BJVO3PDeQ" %}}
+
+---
+
+{{% newsletter-title %}}
+How Celeste Takes a Tittle and Gets a Lot
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+Celeste has a captivating soundtrack, and 8-bit Music Theory does a great breakdown of how one particular composition maximises value for only a few ideas.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://www.youtube.com/watch?v=AeMv8Z0TIos" %}}
+
+---
+
+{{% newsletter-title %}}
+What Bojack Horseman Teaches Us About Character Arcs
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+An interesting study on writing character arcs, looking at Princess Carolyn's arc over the past seasons of Bojack Horseman.
+
+It seems fitting given the second half of the final season will be releasing this month.
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://www.youtube.com/watch?v=bxZFLsfqssM" %}}
+
+---
+
+{{% newsletter-heading "Music" %}}
+
+{{% newsletter-title %}}
+Mr. Finish Line (2017) - Vulfpeck
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+The funky gang's 2017 album features a lot of great standout performances.
+
+Some of my favourite tracks include the eponymous _"Mr. Finish Line"_, _"Tee Time"_ with Woody Goss and closing track _"Captain Hook"_.
+
+Listen carefully for the lyrics "GitHub Bootstrappin'"!
+{{%/ newsletter-description %}}
+{{% newsletter-link "https://www.youtube.com/watch?v=_3T8d50jzTk" "YouTube" %}}
+{{% newsletter-link "https://vulfpeck.bandcamp.com/album/mr-finish-line" "Bandcamp" %}}
+
+---
+
+<!--
+{{% newsletter-heading "" %}}
+
+{{% newsletter-title %}}
+{{%/ newsletter-title %}}
+{{% newsletter-description %}}
+{{%/ newsletter-description %}}
+{{% newsletter-link "" %}}
+
+---
+-->

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -3,6 +3,7 @@
   <head>
     {{ partial "meta.html" . }}
     <meta property="og:type" content="article" />
+    <link rel="stylesheet" type="text/css" href="/main.css" />
     <link rel="stylesheet" type="text/css" href="/blog-article.css" />
   </head>
   <body>

--- a/layouts/_default/resume.html
+++ b/layouts/_default/resume.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     {{ partial "meta.html" . }}
+    <link rel="stylesheet" type="text/css" href="/main.css" />
     <link rel="stylesheet" type="text/css" href="/resume.css" />
   </head>
   <body>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     {{ partial "meta.html" . }}
+    <link rel="stylesheet" type="text/css" href="/main.css" />
   </head>
   <body>
     {{ partial "nav.html" . }} {{ partial "header.html" . }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -3,6 +3,7 @@
   <head>
     {{ partial "meta.html" . }}
     <meta property="og:type" content="article" />
+    <link rel="stylesheet" type="text/css" href="/main.css" />
     <link rel="stylesheet" type="text/css" href="/blog-article.css" />
   </head>
   <body>

--- a/layouts/newsletter/list.html
+++ b/layouts/newsletter/list.html
@@ -1,0 +1,17 @@
+{{ $latestPostLink := "" }}
+<!--  -->
+{{ range first 1 .Pages }} {{ $latestPostLink = .Permalink }} {{ end }}
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {{ partial "meta.html" . }}
+    <meta http-equiv="refresh" content="0; url={{ $latestPostLink }}" />
+  </head>
+  <body>
+    <p>
+      You are being redirected to the
+      <a href="{{ $latestPostLink }}">latest newsletter</a>.
+    </p>
+  </body>
+</html>

--- a/layouts/newsletter/single.html
+++ b/layouts/newsletter/single.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {{ partial "meta.html" . }}
+    <meta property="og:type" content="article" />
+  </head>
+  <body style="margin: 8px; font-family: monospace;">
+    <main
+      style="
+      max-width: 600px;
+      min-width: 300px;
+      margin: 0 auto;
+      background-color: #ddd;
+      padding: 8px 16px;"
+    >
+      <article>
+        <h1>
+          <a style="color: inherit;" href="{{ .Permalink }}">{{ .Title }}</a>
+        </h1>
+        <p>
+          Published {{ .Date.Format "02 Jan 2006" }}
+        </p>
+        <p>
+          {{ .Content }}
+        </p>
+        <p style="display: flex; margin-top: 32px;">
+          {{ if ne .PrevInSection nil }}
+          <a style="color: inherit;" href="{{ .PrevInSection.Permalink }}"
+            ><< Previous</a
+          >
+          {{ end }}
+          <span style="flex: 1;"></span>
+          {{ if ne .NextInSection nil }}
+          <a style="color: inherit;" href="{{ .NextInSection.Permalink }}"
+            >Next >></a
+          >
+        </p>
+        {{ end }}
+      </article>
+    </main>
+  </body>
+</html>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,6 +2,7 @@
   <div class="constrain-width">
     <p>
       <a href="/">Home</a> / <a href="/blog/">Blog</a> /
+      <a href="/newsletter/">Newsletter</a> /
       <a href="{{ .Site.Params.Source }}">Source</a>
     </p>
     <p>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -25,4 +25,3 @@
   content="https://og-image.nchlswhttkr.now.sh/{{ urls.Parse .Title }}.jpeg"
 />
 {{ end }}
-<link rel="stylesheet" type="text/css" href="/main.css" />

--- a/layouts/shortcodes/newsletter-description.html
+++ b/layouts/shortcodes/newsletter-description.html
@@ -1,0 +1,3 @@
+<p style="margin: 8px 0;">
+  {{ .Inner }}
+</p>

--- a/layouts/shortcodes/newsletter-heading.html
+++ b/layouts/shortcodes/newsletter-heading.html
@@ -13,7 +13,7 @@
   style="
   background-color: {{ $color }};
   padding: 4px 0;
-  margin: 8px 0;
+  margin: 32px 0 8px;
   text-align: center
   "
 >

--- a/layouts/shortcodes/newsletter-heading.html
+++ b/layouts/shortcodes/newsletter-heading.html
@@ -1,0 +1,21 @@
+<!-- https://flatuicolors.com/palette/au -->
+{{ $color := "#fff" }}
+<!---->
+{{ if ( eq ( .Get 0 ) "Articles" ) }} {{ $color = "#7ed6df"}} {{ end }}
+<!---->
+{{ if ( eq ( .Get 0 ) "Videos" ) }} {{ $color = "#ff7979"}} {{ end }}
+<!---->
+{{ if ( eq ( .Get 0 ) "Music" ) }} {{ $color = "#badc58"}} {{ end }}
+<!---->
+{{ if ( eq ( .Get 0 ) "Games" ) }} {{ $color = "#ffbe76"}} {{ end }}
+
+<h2
+  style="
+  background-color: {{ $color }};
+  padding: 4px 0;
+  margin: 8px 0;
+  text-align: center
+  "
+>
+  {{ .Get 0 }}
+</h2>

--- a/layouts/shortcodes/newsletter-link.html
+++ b/layouts/shortcodes/newsletter-link.html
@@ -1,0 +1,9 @@
+<p style="margin: 8px 0;text-align: right;">
+  <a
+    href="{{ .Get 0 }}"
+    target="_blank"
+    rel="noreferrer"
+    style="color: inherit;text-decoration-thickness: 2px; font-weight: 700;"
+    >{{ default "View" ( .Get 1 ) }} >></a
+  >
+</p>

--- a/layouts/shortcodes/newsletter-title.html
+++ b/layouts/shortcodes/newsletter-title.html
@@ -1,0 +1,1 @@
+<h3 style="margin: 8px 0;">{{ .Inner }}</h3>

--- a/layouts/shortcodes/newsletter-title.html
+++ b/layouts/shortcodes/newsletter-title.html
@@ -1,1 +1,1 @@
-<h3 style="margin: 8px 0;">{{ .Inner }}</h3>
+<h3 style="margin: 16px 0 8px;">{{ .Inner }}</h3>


### PR DESCRIPTION
Needed to make some styling changes site-wide here, like removing the default CSS from the metadata partial template.

Styles for the newsletter are inlined, so I'm going with shortcodes as a workaround for using classes on elements.

There's a redirect from `/newsletter/` to the latest newsletter, which updates automatically as new pieces are published.